### PR TITLE
Delegate method name

### DIFF
--- a/AdjustableTextField/AdjustableTextField.swift
+++ b/AdjustableTextField/AdjustableTextField.swift
@@ -88,12 +88,12 @@ class AdjustableTextField: NSTextField, NSTextViewDelegate {
         onValueChangedHandler?(value)
 
         //MARK: Delegate style event handler
-        adjustableTextFieldDelegate?.adjustableTextField?(self, didChangeValue: value)
+        adjustableTextFieldDelegate?.adjustableTextField(self, didChangeValue: value)
 
     }
 
 }
 
-@objc protocol AdjustableTextFieldDelegate: class {
-    @objc optional func adjustableTextField(_ adjustableTextField: AdjustableTextField, didChangeValue newValue: Double)
+protocol AdjustableTextFieldDelegate: class {
+    func adjustableTextField(_ adjustableTextField: AdjustableTextField, didChangeValue newValue: Double)
 }

--- a/AdjustableTextField/AdjustableTextField.swift
+++ b/AdjustableTextField/AdjustableTextField.swift
@@ -88,12 +88,12 @@ class AdjustableTextField: NSTextField, NSTextViewDelegate {
         onValueChangedHandler?(value)
 
         //MARK: Delegate style event handler
-        adjustableTextFieldDelegate?.onValueChanged(value)
+        adjustableTextFieldDelegate?.adjustableTextField?(self, didChangeValue: value)
 
     }
 
 }
 
-protocol AdjustableTextFieldDelegate: class {
-    func onValueChanged(_ newValue: Double)
+@objc protocol AdjustableTextFieldDelegate: class {
+    @objc optional func adjustableTextField(_ adjustableTextField: AdjustableTextField, didChangeValue newValue: Double)
 }

--- a/AdjustableTextField/ViewController.swift
+++ b/AdjustableTextField/ViewController.swift
@@ -38,7 +38,7 @@ class ViewController: NSViewController, AdjustableTextFieldDelegate {
         }
     }
 
-    func onValueChanged(_ newValue: Double) {
+    func adjustableTextField(_ adjustableTextField: AdjustableTextField, didChangeValue newValue: Double) {
         delegateValueLabel.stringValue = "\(newValue)"
     }
 


### PR DESCRIPTION
Using this UITableViewDelegate method as an example:

`func tableView(_ tableView: UITableView, willDeselectRowAt indexPath: IndexPath) -> IndexPath?
`

I made the delegate method more Cocoa-like so that you also get a reference to the component in your call back method in case you have multiple controls for the same delegate.

Naturally, we'll need to change all instances of adjustableTextField once we come up with the final name for this component.